### PR TITLE
改修 8グループ 日にち  表示

### DIFF
--- a/app/assets/stylesheets/list.css
+++ b/app/assets/stylesheets/list.css
@@ -43,6 +43,12 @@
   margin-top: 10px;
 }
 
+.date {
+  font-size: 12px;
+  margin: 0 0 0 auto;
+  color: #bfbcbc;
+}
+
 /** カテゴリー用 **/
 .category {
   font-size: 12px;

--- a/app/assets/stylesheets/markdown.css
+++ b/app/assets/stylesheets/markdown.css
@@ -159,7 +159,7 @@
 }
 
 .author-link {
-  margin-left: 0.3rem;
+  margin: 0 0.3rem;
   --bs-btn-padding-y: 0rem;
   --bs-btn-padding-x: 0.1rem;
   --bs-btn-font-size: 0.8rem;

--- a/app/models/concerns/common_methods.rb
+++ b/app/models/concerns/common_methods.rb
@@ -5,4 +5,10 @@ module CommonMethods
   def public?
     is_public
   end
+
+  # 作成日 or 更新日から何日経過したかを返す
+  def days_since_last_update
+    latest_date = [created_at, updated_at].max
+    (Date.today - latest_date.to_date).to_i
+  end
 end

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -1,5 +1,6 @@
 class Prompt < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
+  include CommonMethods
 
   belongs_to :user
   has_many   :notes

--- a/app/views/shared/_basic_info.html.erb
+++ b/app/views/shared/_basic_info.html.erb
@@ -8,13 +8,16 @@
     <% end %>
   </div>
   <div>
-  <strong>NickName:</strong> <%= @user.nickname %>
+    <strong>NickName:</strong> <%= @user.nickname %>
   </div>
   <div>
-  <strong>Email:</strong> <%= @user.email %>
+    <strong>Email:</strong> <%= @user.email %>
   </div>
   <div>
-  <strong>Profile:</strong> <%= simple_format(@user.profile) %>
+    <strong>Group:</strong> <%= @user.group.name %>
+  </div>
+  <div>
+    <strong>Profile:</strong> <%= simple_format(@user.profile) %>
   </div>
   <div class="content-info container mt-4">
     <div class="row mt-4">

--- a/app/views/shared/_note_boxes.html.erb
+++ b/app/views/shared/_note_boxes.html.erb
@@ -15,6 +15,7 @@
     <% end %>
   </div>
   <div class="title"><%= object.title %></div>
+  <div class="date"><%= object.days_since_last_update %>日前</div>
   <div class="footer">
     <%= link_to "Detail", dynamic_path(object, :show), class: 'btn details-button' %>
     <div class="informative"

--- a/app/views/shared/_show_markdown.html.erb
+++ b/app/views/shared/_show_markdown.html.erb
@@ -49,4 +49,5 @@
 </div>
 <div class="author">
   <strong>Author:</strong> <%= link_to object.user.nickname, user_path(object.user), class: 'btn btn-outline-primary btn-sm author-link' %>
+  <strong>Update:</strong> <%= object.days_since_last_update %>日前
 </div>


### PR DESCRIPTION
## What
グループ名と日にちの表示
## Why
・作成、更新してから何日経過しているか分かるようにする為
・グループ名を表示する為